### PR TITLE
Refactor to simpler commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,17 +41,10 @@ Get help::
 
     dmpr --help
 
-Post process a model run::
+Convert output files to compressed CF-NetCDF::
 
-    dmpr post --rundir /path/to/configs output1 output2
+    dmpr standardise --model MOM --output cfoutput.nc output1.nc output2.nc
 
-List registered data management plans::
-
-    dmpr dmp list
-
-Export data management plan 51::
-
-    dmpr dmp export --format=json 51
 
 -------
 Develop

--- a/conda/dev-environment-py2.7.yml
+++ b/conda/dev-environment-py2.7.yml
@@ -1,9 +1,0 @@
-name: dmpr-dev
-
-channels:
-    - ScottWales # For fixed cfchecker
-    - conda-forge
-    - defaults
-
-dependencies:
-    - cfchecker

--- a/conda/dev-environment.yml
+++ b/conda/dev-environment.yml
@@ -14,3 +14,5 @@ dependencies:
     - beautifulsoup4
     - tabulate
     - click
+    - compliance-checker
+    - xarray

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,11 +21,12 @@ requirements:
         - six
         - netcdf4
         - iris
-        - cfchecker # [py27]
         - requests
         - beautifulsoup4
         - tabulate
         - click
+        - xarray
+        - compliance-checker
 
 test:
     source_files:

--- a/dmpr/base.py
+++ b/dmpr/base.py
@@ -29,7 +29,7 @@ class Model(object):
     used by command-line tools
     """
 
-    def standardise(self, infiles, outfile, **kwargs):
+    def standardise(self, infiles, outfile):
         """
         Convert the listed `infiles` to CF-NetCDF file `outfile`
 

--- a/dmpr/base.py
+++ b/dmpr/base.py
@@ -19,136 +19,21 @@ Abstract base classes used by the actual models
 """
 
 from __future__ import print_function
-import os
-import os.path
-import netCDF4
-import sys
-import platform
-from datetime import datetime
-from .dmp import DMP
-from dmpr import __version__
+import xarray
 
 class Model(object):
     """
     Base class of model processors
 
-    .. py:attribute:: run_meta
-
-        Dictionary for extra metadata to be added to the output file.
-        ``run_meta['runid']`` is used to determine the output path
-
-    .. py:attribute:: dmp
-
-        :py:class:`~dmpr.dmp.DMP` attached to this model (may be ``None`` if
-        not known yet)
+    Model classes provide the interface functions given here, which are then
+    used by command-line tools
     """
 
-    def __init__(self):
-        self.user = os.environ.get('USER', 'unknown')
-        self.project = os.environ.get('PROJECT', 'unknown')
-        self.dmp = None
-        self.run_meta = {}
-        self.attr_prefix = 'dmpr.'
-        self.archivedir = os.path.join('/short',self.project,self.user,'dmp')
-
-    def read_configs(self, rundir):
+    def standardise(self, infiles, outfile, **kwargs):
         """
-        Read the run configuration, setting up run-based metadata
+        Convert the listed `infiles` to CF-NetCDF file `outfile`
 
-        To be overridden by model classes
+        Default implementation just compresses the file
         """
-        raise NotImplementedError('To be overridden by the model class')
-
-    def out_dir(self):
-        """
-        Returns the output directory for this model run
-        """
-        return os.path.join(self.archivedir, self.run_meta['runid'])
-
-    def out_filename(self, infile):
-        """
-        Returns the base output filename
-
-        May be overriden by the model class
-
-        :param str infile: Filename of the input file as passed to ``dmpr post``
-
-        >>> Model().out_filename('/path/to/foo.nc')
-        'foo.nc'
-        """
-        return os.path.basename(infile)
-
-    def post(self, infile, outfile=None):
-        """
-        Post-process a file and add metadata from the DMP
-
-        Calls :py:meth:`~Model.post_impl()` to do the main processing, which
-        gets overridden by model classes.
-
-        :param str infile: Filename of the input file
-        :param str outfile: Filename of the output file (defaults to :py:func:`~dmpr.base.Model.out_filename()`)
-        :return: Path to the processed output file
-        :rtype: str
-        """
-        outdir = self.out_dir()
-
-        try:
-            os.makedirs(outdir)
-        except OSError:
-            pass
-
-        if outfile is None:
-            outfile = self.out_filename(infile)
-
-        outfile = os.path.join(outdir, outfile)
-        self.post_impl(infile, outfile)
-
-        self.add_meta(infile, outfile)
-
-        return outfile
-
-    def post_impl(self, infile, outfile):
-        """
-        Post-processing implementation
-
-        Must be overridden by the model class
-
-        :param str infile: Filename of the input file
-        :param str outfile: Filename of the output file (created by this function)
-        """
-        raise NotImplementedError('To be overridden by the model class')
-
-    def add_meta(self, infile, outfile):
-        """
-        Add file-level metadata to the processed file, including history and
-        anything added to the dictionary :py:attr:`Model.run_meta`.
-
-        :param str infile: Filename of the input file
-        :param str outfile: Filename of the output file
-        """
-        with netCDF4.Dataset(outfile, mode="a") as f:
-            if self.dmp is not None:
-                f.setncatts(self.dmp.file_metadata())
-
-            f.setncatts(self.run_meta)
-
-            add_history(f, infile)
-
-def add_history(dataset, infile):
-    """
-    Add history information to a dataset
-
-    :param netCDF4.Dataset dataset: Dataset to modify
-    :param str infile: Filename of the input file
-    """
-    try:
-        history = dataset.getncattr('history')
-    except AttributeError:
-        history = ""
-    history += "%s %s:%s(%s) post %s\n"%(
-            datetime.now().isoformat(),
-            platform.node(),
-            sys.argv[0], __version__,
-            infile)
-    dataset.setncattr('history', history)
-
+        data = xarray.open_mfdataset(infiles, decode_times=False)
+        data.to_netcdf(outfile, encoding = {key: {'zlib': True} for key in data.variables.keys()})

--- a/dmpr/model.py
+++ b/dmpr/model.py
@@ -17,19 +17,6 @@ from __future__ import print_function
 from .um.model import UM
 from .mom.model import MOM
 
-def identify_model(path):
-    """
-    Identify the model under path
-
-    >>> identify_model('test/sample/um').name
-    'UM'
-    """
-
-    if 'mom' in path:
-        return MOM()
-    elif 'um' in path:
-        return UM()
-
 def model_from_name(name):
     """
     Return the model object for a given name

--- a/dmpr/mom/model.py
+++ b/dmpr/mom/model.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 from __future__ import print_function
 from ..base import Model
-import netCDF4
-
-import shutil
 
 class MOM(Model):
     """

--- a/dmpr/mom/model.py
+++ b/dmpr/mom/model.py
@@ -23,11 +23,7 @@ class MOM(Model):
     """
     A MOM model run
     """
-    name = 'MOM'
 
     def __init__(self):
         super(MOM,self).__init__()
-        self.run_meta['runid'] = 'tmp'
 
-    def post_impl(self, infile, outfile):
-        shutil.copy(infile, outfile)

--- a/dmpr/um/model.py
+++ b/dmpr/um/model.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 from ..base import Model
 import iris
 import iris.fileformats.netcdf
-import os
 import netCDF4
 
 class UM(Model):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages =
 
 [entry_points]
 console_scripts = 
-    dmpr = dmpr.cli:main
+    dmpr = dmpr.cli:dmpr
 
 [pbr]
 autodoc_tree_index_modules = True

--- a/test/mom/test_mom.py
+++ b/test/mom/test_mom.py
@@ -18,59 +18,44 @@ limitations under the License.
 """
 
 from dmpr.mom.model import *
-from dmpr.model import identify_model
 
 import os
-import netCDF4
 import pytest
+import sys
+from pprint import PrettyPrinter
+from compliance_checker.suite import CheckSuite
 
-sample = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
+sampledir = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
 
-def test_identify_model():
-    assert isinstance(identify_model(sample), MOM)
-    
+@pytest.fixture(scope='module')
+def pprinter():
+    return PrettyPrinter(stream=sys.stderr)
+
 @pytest.fixture(scope='module')
 def archivedir(tmpdir_factory):
-    return str(tmpdir_factory.mktemp('um'))
+    return str(tmpdir_factory.mktemp('mom'))
 
 @pytest.fixture(scope='module')
-def sample_out(archivedir):
-    """
-    Returns a processed output file
-    """
+def standardised(archivedir):
     model = MOM()
-    model.archivedir = archivedir
 
-    infile = os.path.join(sample, 'ocean_month.nc')
-    outfile = model.post(infile)
+    outfile = os.path.join(archivedir, 'ocean_daily.nc')
+
+    model.standardise(
+            [os.path.join(sampledir, 'ocean_daily.nc')],
+            outfile)
+
     return outfile
 
-def test_metadata(sample_out):
-    with netCDF4.Dataset(sample_out) as d:
-        # There is a history present
-        assert d.getncattr('history') is not None
+def test_standardise_exists(standardised):
+    assert os.path.isfile(standardised)
 
-def test_cfcheck(sample_out, cfchecker):
-    # Output is CF compliant
-    assert cfchecker.checker(sample_out) == 0
+def test_standardise_cf(standardised, pprinter):
+    suite = CheckSuite()
+    suite.load_all_available_checkers()
 
-@pytest.fixture(scope='module')
-def sample_dmp(archivedir, dmp):
-    """
-    Returns a processed output file
-    """
-    model = MOM()
-    model.archivedir = archivedir
-    model.dmp = dmp
+    ds = suite.load_dataset(standardised)
+    results = suite.run(ds, [], 'cf')
 
-    infile = os.path.join(sample, 'ocean_month.nc')
-    outfile = model.post(infile, 'ocean_month.dmp.nc')
-    return outfile
-
-def test_metadata_dmp(sample_dmp):
-    with netCDF4.Dataset(sample_dmp) as d:
-        assert d.getncattr('data_management_plan') is not None
-
-def test_cfcheck_dmp(sample_dmp, cfchecker):
-    # Output is CF compliant
-    assert cfchecker.checker(sample_dmp) == 0
+    pprinter.pprint(results['cf'][0])
+    assert results['cf'][0] is []

--- a/test/mom/test_mom.py
+++ b/test/mom/test_mom.py
@@ -22,14 +22,9 @@ from dmpr.mom.model import *
 import os
 import pytest
 import sys
-from pprint import PrettyPrinter
 from compliance_checker.suite import CheckSuite
 
 sampledir = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
-
-@pytest.fixture(scope='module')
-def pprinter():
-    return PrettyPrinter(stream=sys.stderr)
 
 @pytest.fixture(scope='module')
 def archivedir(tmpdir_factory):
@@ -50,12 +45,17 @@ def standardised(archivedir):
 def test_standardise_exists(standardised):
     assert os.path.isfile(standardised)
 
-def test_standardise_cf(standardised, pprinter):
+def test_standardise_cf(standardised):
     suite = CheckSuite()
     suite.load_all_available_checkers()
 
     ds = suite.load_dataset(standardised)
     results = suite.run(ds, [], 'cf')
 
-    pprinter.pprint(results['cf'][0])
-    assert results['cf'][0] is []
+    check_failures = 0
+    for r in results['cf'][0]:
+        if r.value[1] - r.value[0] > 0:
+            print(r, file=sys.stderr)
+            check_failures += 1
+
+    assert check_failures == 0

--- a/test/um/test_um.py
+++ b/test/um/test_um.py
@@ -22,14 +22,9 @@ from dmpr.um.model import *
 import os
 import pytest
 import sys
-from pprint import PrettyPrinter
 from compliance_checker.suite import CheckSuite
 
 sampledir = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
-
-@pytest.fixture(scope='module')
-def pprinter():
-    return PrettyPrinter(stream=sys.stderr)
 
 @pytest.fixture(scope='module')
 def archivedir(tmpdir_factory):
@@ -50,12 +45,17 @@ def standardised(archivedir):
 def test_standardise_exists(standardised):
     assert os.path.isfile(standardised)
 
-def test_standardise_cf(standardised, pprinter):
+def test_standardise_cf(standardised):
     suite = CheckSuite()
     suite.load_all_available_checkers()
 
     ds = suite.load_dataset(standardised)
     results = suite.run(ds, [], 'cf')
 
-    pprinter.pprint(results['cf'][0])
-    assert results['cf'][0] is []
+    check_failures = 0
+    for r in results['cf'][0]:
+        if r.value[1] - r.value[0] > 0:
+            print(r, file=sys.stderr)
+            check_failures += 1
+
+    assert check_failures == 0

--- a/test/um/test_um.py
+++ b/test/um/test_um.py
@@ -18,66 +18,44 @@ limitations under the License.
 """
 
 from dmpr.um.model import *
-from dmpr.model import identify_model
 
 import os
-import netCDF4
 import pytest
+import sys
+from pprint import PrettyPrinter
+from compliance_checker.suite import CheckSuite
 
-sample = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
+sampledir = os.path.join(os.path.dirname(os.path.realpath(__file__)),'sample')
 
-def test_identify_model():
-    assert isinstance(identify_model(sample), UM)
-    
-def test_read_config():
-    model = UM()
-    model.read_configs(sample)
-    assert model.run_meta['runid'] == 'abcde'
+@pytest.fixture(scope='module')
+def pprinter():
+    return PrettyPrinter(stream=sys.stderr)
 
 @pytest.fixture(scope='module')
 def archivedir(tmpdir_factory):
     return str(tmpdir_factory.mktemp('um'))
 
 @pytest.fixture(scope='module')
-def sample_out(archivedir):
-    """
-    Returns a processed output file
-    """
+def standardised(archivedir):
     model = UM()
-    model.read_configs(sample)
-    model.archivedir = archivedir
 
-    infile = os.path.join(sample, 'abcdea_da000')
-    outfile = model.post(infile)
+    outfile = os.path.join(archivedir, 'abcdea_da000.nc')
+
+    model.standardise(
+            [os.path.join(sampledir, 'abcdea_da000')],
+            outfile)
+
     return outfile
 
-def test_metadata(sample_out):
-    with netCDF4.Dataset(sample_out) as d:
-        # There is a history present
-        assert d.getncattr('history') is not None
+def test_standardise_exists(standardised):
+    assert os.path.isfile(standardised)
 
-def test_cfcheck(sample_out, cfchecker):
-    # Output is CF compliant
-    assert cfchecker.checker(sample_out) == 0
+def test_standardise_cf(standardised, pprinter):
+    suite = CheckSuite()
+    suite.load_all_available_checkers()
 
-@pytest.fixture(scope='module')
-def sample_dmp(archivedir, dmp):
-    """
-    Returns a processed output file
-    """
-    model = UM()
-    model.read_configs(sample)
-    model.archivedir = archivedir
-    model.dmp = dmp
+    ds = suite.load_dataset(standardised)
+    results = suite.run(ds, [], 'cf')
 
-    infile = os.path.join(sample, 'abcdea_da000')
-    outfile = model.post(infile, 'abcdea_da000.dmp.nc')
-    return outfile
-
-def test_metadata_dmp(sample_dmp):
-    with netCDF4.Dataset(sample_dmp) as d:
-        assert d.getncattr('data_management_plan') is not None
-
-def test_cfcheck_dmp(sample_dmp, cfchecker):
-    # Output is CF compliant
-    assert cfchecker.checker(sample_dmp) == 0
+    pprinter.pprint(results['cf'][0])
+    assert results['cf'][0] is []


### PR DESCRIPTION
Major refactor, rip out the workflow stuff in preference to simple, composable commands, starting with `standardise`. 

The `standardise` command converts model output files to compressed CF-NetCDF format. The default behaviour in dmpr/base.py is to copy using `xarray`, but this can be specialised for each model.

The `standardise` command is tested using the IOOS compliance checker to make sure it meets CF standards. This seems to be much stricter than `cfchecker`